### PR TITLE
Setup Travis CI for macOS and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ tags
 .DS_Store
 .directory
 *.debug
-Makefile*
 *.prl
 *.app
 moc_*.cpp
@@ -34,6 +33,7 @@ Thumbs.db
 *.rc
 /.qmake.cache
 /.qmake.stash
+build
 
 # qtcreator generated files
 *.pro.user*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# Configuration file for Travis CI
+
+language: cpp
+
+# Only build pushes to the master branch and tags. This avoids the double
+# builds than happen when working on a branch instead of a fork.
+branches:
+  only:
+    - master
+    # Regex to build tagged commits with version numbers
+    - /\d+\.\d+(\.\d+)?(\S*)?$/
+
+jobs:
+  include:
+    - os: linux
+      dist: bionic
+      sudo: required
+      env: PATH="/opt/qt514/bin:$PATH"
+      before_install:
+      - sudo add-apt-repository ppa:beineri/opt-qt-5.14.0-bionic -y
+      - sudo apt-get update
+      - sudo apt-get install qt514-meta-minimal libglu1-mesa-dev
+    - os: osx
+      osx_image: xcode11.3
+      env: PATH="/usr/local/opt/qt/bin:$PATH"
+      before_install:
+      # Travis CI already has qt 5.13 installed
+      - brew reinstall qt
+script:
+  - qmake --version
+  - make build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build:
+	mkdir build; \
+	cd build; \
+	qmake ../src/GMT-GUI.pro; \
+	make -j
+
+clean:
+	rm -r build

--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 https://github.com/CovMat/GMT-mini-GUI/releases
 
 ## 注意事项
+
 ### GMT
-使用本工具前请先在您的系统中安装好GMT，版本最低要求为5.4。  
-安装指南：https://docs.gmt-china.org/6.0/install/ （6.0版）、https://docs.gmt-china.org/5.4/install/ （5.4版）  
+
+使用本工具前请先在您的系统中安装好GMT，版本最低要求为5.4。
+安装指南：https://docs.gmt-china.org/6.0/install/ （6.0版）、https://docs.gmt-china.org/5.4/install/ （5.4版）
+
 ### Ghostscript
+
 为了保证GMT的psconvert正常运行，生成本工具需要的预览图片，用户需要安装Ghostscript。
-一般来说，如果按照上面给出的GMT安装指南完整安装的话，用户的系统中已经安装好了Ghostscript。如果没安装Ghostscript，请参照GMT安装指南安装对应系统的Ghostscript。  
-### 自行编译
-如果想自行编译源代码，请使用Qt 5.13版。已知Qt 5.14版存在bug，无法编译。
-在Mac系统中编译时，除了Qt之外，还必须同时安装xcode 10(xcode 11与Qt 5.13不兼容)。
+一般来说，如果按照上面给出的GMT安装指南完整安装的话，用户的系统中已经安装好了Ghostscript。如果没安装Ghostscript，请参照GMT安装指南安装对应系统的Ghostscript。
 
 ## 运行方法
 
@@ -23,7 +24,7 @@ https://github.com/CovMat/GMT-mini-GUI/releases
 
 ### Linux
 
-下载安装包，解压，打开终端进入文件夹，终端运行 `./GMT-GUI`。  
+下载安装包，解压，打开终端进入文件夹，终端运行 `./GMT-GUI`。
 如果不从终端运行的话（例如直接双击运行），无法继承环境变量PATH，会出现找不到GMT路径的错误。
 
 ### macOS


### PR DESCRIPTION
Changes in this PR:

1. Rename `readme.md` to `README.md`. Most projects use `README.md` instead of `readme.md`;
2. Add a Travis CI script to build the project on Linux and macOS
3. Add a Makefile to build the project on Linux and macOS, the build happens in the `build` directory, to avoid generating any files in the `src` directory.
4. Qt 5.14 works well on Linux.
5. Qt 5.14 works well with xcode 11.3