### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GMT-mini-GUI
 
-![GitHub](https://img.shields.io/github/license/CovMat/GMT-mini-GUI)
+[![GitHub](https://img.shields.io/github/license/CovMat/GMT-mini-GUI)](https://github.com/CovMat/GMT-mini-GUI/blob/master/LICENSE)
 [![Build Status](https://travis-ci.org/CovMat/GMT-mini-GUI.svg?branch=master)](https://travis-ci.org/CovMat/GMT-mini-GUI)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/CovMat/GMT-mini-GUI)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/CovMat/GMT-mini-GUI)](https://github.com/CovMat/GMT-mini-GUI/releases)
 
 ## 下载地址
 
@@ -19,13 +19,12 @@ https://github.com/CovMat/GMT-mini-GUI/releases
 
 为了保证GMT的psconvert正常运行，生成本工具需要的预览图片，用户需要安装Ghostscript。
 
-有用户反馈指出，GMT6.0自带的Ghostscript版本太低，导致psconvert无法正常转换png格式的图片。因此我们强烈建议**所有用户在使用本工具前都要将Ghostscript升级到最新版**。
-
-Windows平台的最新版Ghostscript下载地址为：https://www.ghostscript.com/download/gsdnld.html  
-Linux平台建议使用自带的软件仓库工具升级Ghostscript。  
+Windows平台的最新版Ghostscript下载地址为：https://www.ghostscript.com/download/gsdnld.html
+Linux平台建议使用自带的软件仓库工具升级Ghostscript。
 Mac用户请参考社区指南安装Ghostscript：https://docs.gmt-china.org/6.0/install/macOS/#homebrew
 
 ### 自行编译
+
 在windows下编译时，请使用MinGW作为Qt creator的编译工具。Linux下部分发行版的系统在使用Qt 5.14时会出现与QColor有关的编译错误，如果出现这种情况请卸载安装Qt 5.13。
 
 ## 运行方法
@@ -53,4 +52,4 @@ Mac用户请参考社区指南安装Ghostscript：https://docs.gmt-china.org/6.0
 
 ## 许可协议
 
-本项目使用 [MIT license](https://github.com/CovMat/GMT-mini-GUI/blob/master/LICENSE) 许可协议
+本项目使用 [MIT license](LICENSE) 许可协议。


### PR DESCRIPTION
- Link badges to LICENCE page and release page, respectively
- GMT6 Windows installers ship latest ghostscript. No need to upgrade