### PR TITLE
Deploy macOS package  to FTP via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,20 @@ jobs:
       before_install:
       # Travis CI already has qt 5.13 installed
       - brew reinstall qt
+
 script:
+  # Check qmake --version
   - qmake --version
+  # Building
   - make build
+
+after_success:
+  # Packaging
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make macos_package; fi
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: if [ "$TRAVIS_OS_NAME" = "osx" ]; then curl -T build/GMT-GUI.app.zip -u $FTP_USER:$FTP_PASSWORD ftp://home.ustc.edu.cn/public_html/; fi
+  on:
+    branch: master

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
+# Build for Linux/macOS
 build:
 	mkdir build; \
 	cd build; \
 	qmake ../src/GMT-GUI.pro; \
 	make -j
+
+# Package for macOS
+macos_package: build
+	cd build; \
+	macdeployqt GMT-GUI.app; \
+	zip -r GMT-GUI.app.zip GMT-GUI.app
 
 clean:
 	rm -r build


### PR DESCRIPTION
For each commit to master branch, travis will build a macOS package and deploy it to FTP.

Variables FTP_USER and FTP_PASSWORD need to be defined in the Travis admin panel.